### PR TITLE
update the modal to use transaction modal component

### DIFF
--- a/src/components/TransactionModal/TransactionModal.tsx
+++ b/src/components/TransactionModal/TransactionModal.tsx
@@ -35,13 +35,11 @@ export default function TransactionModal({ show, title, children, handleBack, ha
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, scale: 0.8 }}
                     >
-                        {Boolean(title) && (
-                            <TopWrapper>
-                                <Title>{title}</Title>
-                                {backIcon}
-                                {closeIcon}
-                            </TopWrapper>
-                        )}
+                        <TopWrapper>
+                            {title ? <Title>{title}</Title> : <div />}
+                            {backIcon}
+                            {closeIcon}
+                        </TopWrapper>
 
                         {children}
                     </BoxWrapper>

--- a/src/components/TransactionModal/styles.ts
+++ b/src/components/TransactionModal/styles.ts
@@ -7,7 +7,7 @@ export const Wrapper = styled('div')`
     height: 100%;
     top: 0;
     left: 0;
-    z-index: 99999;
+    z-index: 999;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -15,10 +15,6 @@ export const Wrapper = styled('div')`
     overflow: hidden;
     overflow-y: auto;
     padding: 40px;
-
-    @media (max-height: 800px) {
-        align-items: flex-start;
-    }
 `;
 
 export const Cover = styled(m.div)<{ $noClose?: boolean }>`

--- a/src/components/TransactionModal/styles.ts
+++ b/src/components/TransactionModal/styles.ts
@@ -15,6 +15,10 @@ export const Wrapper = styled('div')`
     overflow: hidden;
     overflow-y: auto;
     padding: 40px;
+
+    @media (max-height: 800px) {
+        align-items: flex-start;
+    }
 `;
 
 export const Cover = styled(m.div)<{ $noClose?: boolean }>`

--- a/src/containers/floating/WalletConnections/WalletConnections.style.ts
+++ b/src/containers/floating/WalletConnections/WalletConnections.style.ts
@@ -1,40 +1,10 @@
 import { styled } from 'styled-components';
-import * as motion from 'motion/react-m';
-
-export const WalletConnectionOverlay = styled(motion.div)`
-    position: fixed;
-    inset: 0;
-    z-index: 100;
-    background-color: rgba(0, 0, 0, 0.3);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-`;
-
-export const WalletConnectionsContainer = styled.div`
-    max-height: calc(100vh - 20px);
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-    background: rgba(255, 255, 255, 0.7);
-    box-shadow: 0px 4px 74px 0px #00000026;
-    backdrop-filter: blur(50px);
-    border-radius: 20px;
-    padding: 20px;
-    min-width: 400px;
-    min-height: 340px;
-    overflow-x: hidden;
-`;
 
 export const WalletConnectHeader = styled.div`
     margin-bottom: 20px;
-    font-family: Poppins;
+    font-family: Poppins, sans-serif;
     font-weight: 600;
     font-size: 21px;
-    leading-trim: Cap height;
     line-height: 31px;
     color: black;
     padding-left: 15px;
@@ -43,31 +13,13 @@ export const WalletConnectHeader = styled.div`
     align-items: center;
 `;
 
-export const TopArea = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-`;
-
-export const IconContainer = styled.div`
-    color: black;
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 30px;
-    height: 30px;
-    border-radius: 50%;
-    background: rgba(255, 255, 255, 0.5);
-`;
-
 export const ContentWrapper = styled.div`
     display: flex;
     flex-direction: column;
     background: white;
     border-radius: 24px;
     padding: 24px;
-    min-width: 480px;
+    width: 100%;
 `;
 
 export const ConnectButton = styled.button`
@@ -79,7 +31,7 @@ export const ConnectButton = styled.button`
     background: white;
     color: black;
     gap: 16px;
-    font-family: Poppins;
+    font-family: Poppins, sans-serif;
     font-weight: 600;
     font-size: 14px;
     line-height: 100%;
@@ -101,7 +53,6 @@ export const Divider = styled.div`
 
 export const WalletAddress = styled.div`
     color: black;
-    ellipsis: true;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/containers/floating/WalletConnections/sections/ConnectWallet/ConnectWallet.tsx
+++ b/src/containers/floating/WalletConnections/sections/ConnectWallet/ConnectWallet.tsx
@@ -1,4 +1,4 @@
-import { ConnectButton, ContentWrapper, WalletConnectHeader } from '../../WalletConnections.style';
+import { ConnectButton, ContentWrapper } from '../../WalletConnections.style';
 import { Divider } from '@app/components/elements/Divider';
 import { useAppKitWallet } from '@reown/appkit-wallet-button/react';
 import MMFox from '../../icons/mm-fox';
@@ -16,27 +16,21 @@ export const ConnectWallet = () => {
         },
     });
     return (
-        <>
-            <WalletConnectHeader>
-                <span>{'Connect a Wallet'}</span>
-
-            </WalletConnectHeader>
-            <ContentWrapper>
-                <ConnectButton onClick={() => connect('portal')}>
-                    <img src={Portal} alt="Portal" width="40" />
-                    <span>{'Portal Wallet'}</span>
-                </ConnectButton>
-                <Divider />
-                <ConnectButton onClick={() => connect('metamask')}>
-                    <MMFox width="25" />
-                    <span>{'Metamask'}</span>
-                </ConnectButton>
-                <Divider />
-                <ConnectButton onClick={() => connect('phantom')}>
-                    <img src={Phantom} alt="Phantom" />
-                    <span>{'Phantom'}</span>
-                </ConnectButton>
-            </ContentWrapper>
-        </>
+        <ContentWrapper>
+            <ConnectButton onClick={() => connect('portal')}>
+                <img src={Portal} alt="Portal" width="40" />
+                <span>{'Portal Wallet'}</span>
+            </ConnectButton>
+            <Divider />
+            <ConnectButton onClick={() => connect('metamask')}>
+                <MMFox width="25" />
+                <span>{'Metamask'}</span>
+            </ConnectButton>
+            <Divider />
+            <ConnectButton onClick={() => connect('phantom')}>
+                <img src={Phantom} alt="Phantom" />
+                <span>{'Phantom'}</span>
+            </ConnectButton>
+        </ContentWrapper>
     );
 };

--- a/src/containers/floating/WalletConnections/sections/Swap/Swap.styles.ts
+++ b/src/containers/floating/WalletConnections/sections/Swap/Swap.styles.ts
@@ -37,7 +37,7 @@ export const SelectedChainInfo = styled.div`
 `;
 
 export const SwapOption = styled.div`
-    min-width: 470px;
+    width: 100%;
     margin-top: 5px;
     padding: 20px;
     display: flex;

--- a/src/containers/floating/WalletConnections/sections/Swap/Swap.tsx
+++ b/src/containers/floating/WalletConnections/sections/Swap/Swap.tsx
@@ -121,7 +121,7 @@ export const Swap = () => {
     return (
         <>
             <WalletConnectHeader>
-                <span>{'Review'}</span>
+                <span />
                 <SelectedChain>
                     {activeChainIcon}
                     <SelectedChainInfo>

--- a/src/containers/floating/WalletConnections/sections/WalletContents/WalletContents.tsx
+++ b/src/containers/floating/WalletConnections/sections/WalletContents/WalletContents.tsx
@@ -53,7 +53,6 @@ export const WalletContents = () => {
 
     return (
         <WalletContentsContainer>
-            <WalletConnectHeader>{'Wallet connected'}</WalletConnectHeader>
             <ConnectedWalletWrapper>
                 <WalletButton variant="error" onClick={() => disconnect()}>
                     {'Disconnect'}

--- a/src/containers/floating/WalletConnections/sections/WalletContents/WalletContents.tsx
+++ b/src/containers/floating/WalletConnections/sections/WalletContents/WalletContents.tsx
@@ -1,4 +1,4 @@
-import { ContentWrapper, WalletAddress, WalletConnectHeader } from '../../WalletConnections.style';
+import { ContentWrapper, WalletAddress } from '../../WalletConnections.style';
 import { useDisconnect } from '@reown/appkit/react';
 import MMFox from '../../icons/mm-fox';
 import { useAccount, useBalance } from 'wagmi';


### PR DESCRIPTION
This updates the modal in the Swaps component to use the same `TransactionModal` as the Send / Receive UI

![CleanShot 2025-04-25 at 18 00 07@2x](https://github.com/user-attachments/assets/d8782608-8f3f-43c6-b053-6ee559d196cb)
